### PR TITLE
[feat] 게시글 관련 기능 API 구현

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,6 +93,38 @@ app.post('/api/groups/:groupId/posts', async (req, res) => {
   }
 });
 
+// 포스트 삭제
+app.delete('/api/posts/:postId', async (req, res) => {
+  const { postId } = req.params;
+  const { postPassword } = req.body; 
+
+  try {
+    const post = await prisma.post.findUnique({
+      where: { id: parseInt(postId) }
+    });
+
+    if (!post) {
+      return res.status(404).json({ error: 'Post not found' });
+    }
+
+    if (post.postPassword !== postPassword) {
+      return res.status(403).json({ error: 'Invalid post password' });
+    }
+    await prisma.tag.deleteMany({
+      where: { postId: parseInt(postId) }
+    });
+
+    await prisma.post.delete({
+      where: { id: parseInt(postId) }
+    });
+
+    res.status(200).send(); 
+
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});햐
 
 
 const PORT = process.env.PORT || 3000;

--- a/app.js
+++ b/app.js
@@ -1,11 +1,101 @@
-const express = require('express')
-const app = express()
-const port = 3000
+const express = require('express');
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+const app = express();
 
-app.get('/', (req, res) => {
-  res.send('Hello World!')
-})
+app.use(express.json());
 
-app.listen(port, () => {
-  console.log(`Example app listening on port ${port}`)
-})
+
+//포스트 작성
+// 포스트 작성
+app.post('/api/groups/:groupId/posts', async (req, res) => {
+  const { groupId } = req.params;
+  const {
+    nickname,
+    title,
+    content,
+    postPassword,
+    groupPassword,
+    imageUrl,
+    tags, 
+    location,
+    moment,
+    isPublic
+  } = req.body;
+
+  try {
+    const group = await prisma.group.findUnique({
+      where: { id: parseInt(groupId) }
+    });
+
+    if (!group) {
+      return res.status(404).json({ error: 'Group not found' });
+    }
+
+    if (group.groupPassword !== groupPassword) {
+      return res.status(403).json({ error: 'Invalid group password' });
+    }
+
+    const tagList = tags.split(',').map(tag => tag.trim()).filter(tag => tag !== '');
+
+    const existingTags = await prisma.tag.findMany({
+      where: {
+        name: { in: tagList }
+      }
+    });
+
+    const existingTagNames = existingTags.map(tag => tag.name);
+    const newTags = tagList
+      .filter(tag => !existingTagNames.includes(tag))
+      .map(tag => ({ name: tag }));
+
+    const newPost = await prisma.post.create({
+      data: {
+        nickname,
+        title,
+        content,
+        postPassword,
+        imageUrl,
+        location,
+        moment: new Date(moment),
+        createAt: new Date(),
+        isPublic,
+        group: {
+          connect: { id: parseInt(groupId) }
+        },
+        tags: {
+          create: newTags
+        }
+      },
+      include: {
+        tags: true 
+      }
+    });
+
+    res.json({
+      id: newPost.id,
+      groupId: newPost.groupId,
+      nickname: newPost.nickname,
+      title: newPost.title,
+      content: newPost.content,
+      imageUrl: newPost.imageUrl,
+      tags: newPost.tags.map(tag => tag.name),
+      location: newPost.location,
+      moment: newPost.moment.toISOString().split('T')[0],
+      isPublic: newPost.isPublic,
+      likeCount: newPost.likeCount,
+      commentCount: newPost.commentCount,
+      createdAt: newPost.createAt.toISOString()
+    });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`);
+});

--- a/app.js
+++ b/app.js
@@ -5,8 +5,6 @@ const app = express();
 
 app.use(express.json());
 
-
-//포스트 작성
 // 포스트 작성
 app.post('/api/groups/:groupId/posts', async (req, res) => {
   const { groupId } = req.params;
@@ -124,7 +122,45 @@ app.delete('/api/posts/:postId', async (req, res) => {
     console.error(error);
     res.status(500).json({ error: 'Internal server error' });
   }
-});햐
+});
+
+// 포스트 상세 조회
+app.get('/api/posts/:postId', async (req, res) => {
+  const { postId } = req.params;
+
+  try {
+    const post = await prisma.post.findUnique({
+      where: { id: parseInt(postId) },
+      include: { tags: true }
+    });
+
+    if (!post) {
+      return res.status(404).json({ error: 'Post not found' });
+    }
+
+    const formattedPost = {
+      id: post.id,
+      groupId: post.groupId,
+      nickname: post.nickname,
+      title: post.title,
+      content: post.content,
+      imageUrl: post.imageUrl,
+      tags: post.tags.map(tag => tag.name), 
+      location: post.location,
+      moment: post.moment.toISOString().split('T')[0], 
+      isPublic: post.isPublic,
+      likeCount: post.likeCount,
+      commentCount: post.commentCount,
+      createdAt: post.createAt.toISOString() 
+    };
+
+    res.json(formattedPost);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 
 
 const PORT = process.env.PORT || 3000;

--- a/prisma/migrations/20241015123113_init/migration.sql
+++ b/prisma/migrations/20241015123113_init/migration.sql
@@ -21,6 +21,7 @@ CREATE TABLE `Post` (
 CREATE TABLE `Tag` (
     `id` INTEGER NOT NULL AUTO_INCREMENT,
     `name` VARCHAR(191) NOT NULL,
+    `postId` INTEGER NOT NULL,
 
     UNIQUE INDEX `Tag_name_key`(`name`),
     PRIMARY KEY (`id`)
@@ -30,25 +31,16 @@ CREATE TABLE `Tag` (
 CREATE TABLE `Group` (
     `id` INTEGER NOT NULL AUTO_INCREMENT,
     `name` VARCHAR(191) NOT NULL,
+    `description` VARCHAR(191) NOT NULL,
+    `groupImageUrl` VARCHAR(191) NOT NULL,
     `groupPassword` VARCHAR(191) NOT NULL,
+    `isGroupPublic` BOOLEAN NOT NULL,
 
     PRIMARY KEY (`id`)
-) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
--- CreateTable
-CREATE TABLE `_PostTags` (
-    `A` INTEGER NOT NULL,
-    `B` INTEGER NOT NULL,
-
-    UNIQUE INDEX `_PostTags_AB_unique`(`A`, `B`),
-    INDEX `_PostTags_B_index`(`B`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- AddForeignKey
 ALTER TABLE `Post` ADD CONSTRAINT `Post_groupId_fkey` FOREIGN KEY (`groupId`) REFERENCES `Group`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE `_PostTags` ADD CONSTRAINT `_PostTags_A_fkey` FOREIGN KEY (`A`) REFERENCES `Post`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE `_PostTags` ADD CONSTRAINT `_PostTags_B_fkey` FOREIGN KEY (`B`) REFERENCES `Tag`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE `Tag` ADD CONSTRAINT `Tag_postId_fkey` FOREIGN KEY (`postId`) REFERENCES `Post`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ model Post {
   imageUrl      String
   location      String
   moment        DateTime
-  createAt        DateTime
+  createAt       DateTime
   isPublic      Boolean
   likeCount     Int      @default(0) 
   commentCount  Int      @default(0)
@@ -26,14 +26,18 @@ model Post {
 }
 
 model Tag {
-  id    Int     @id @default(autoincrement())
-  name  String  @unique
-  posts Post[]  @relation("PostTags")
+  id      Int     @id @default(autoincrement())
+  name    String  @unique
+  postId  Int
+  post    Post   @relation("PostTags", fields: [postId], references: [id])
 }
 
 model Group {
   id            Int      @id @default(autoincrement())
   name          String
+  description   String
+  groupImageUrl String
   groupPassword String
+  isGroupPublic Boolean
   posts         Post[]   @relation("GroupPosts")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,7 +27,7 @@ model Post {
 
 model Tag {
   id      Int     @id @default(autoincrement())
-  name    String  @unique
+  name    String 
   postId  Int
   post    Post   @relation("PostTags", fields: [postId], references: [id])
 }


### PR DESCRIPTION
## Related Issue ✨️

- close : #1

## Summary ✨️
-  게시글 생성 API 구현
<img width="843" alt="스크린샷 2024-10-16 오전 12 35 38" src="https://github.com/user-attachments/assets/175ac1e5-873d-4219-9bb2-c63a3f060913">

-  게시글 삭제 API 구현
<img width="822" alt="스크린샷 2024-10-16 오전 12 36 18" src="https://github.com/user-attachments/assets/6c68d95a-5a39-4689-bd77-0983b23971da">

- 게시글 상세 정보 조회 API 구현
<img width="839" alt="스크린샷 2024-10-16 오전 12 36 33" src="https://github.com/user-attachments/assets/e0db5902-fb68-4f7e-b02d-1ca22216b0ee">

- 게시글 목록 조회 API 구현
<img width="819" alt="스크린샷 2024-10-16 오전 12 37 18" src="https://github.com/user-attachments/assets/b087f38c-4b50-4f8c-85d4-810c9f8f0e2a">

## 전달사항 ✨️
- groupPassword와 postPassword는 1234로 지정했습니다.
- 게시글 목록 조회 API에서 http method가 get이라 body가 아닌 query 파라미터로 보냈습니다. 나머지 API는 명세와 동일합니다(엔드포인트, 파라미터 등)
- sortBy는 latest | mostCommented | mostLiked 중에 사용 가능합니다.